### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```
 npm install --save-dev ember-template-lint-plugin-peopleconnect
-ember install ember-cli-template-lint
+ember install ember-template-lint
 ```
 
 Then inside of your newly generated `/.template-lintrc.js`:


### PR DESCRIPTION
If merged, this PR updates the README to instruct use of to ember-template-lint instead of ember-cli-template-lint.